### PR TITLE
fix: Removes `x-powered-by` header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const defaultOptions = {
 
 module.exports = (userOptions = {}) => {
   const app = express();
+  app.disable('x-powered-by');
   const options = Object.assign({}, defaultOptions, userOptions);
 
   const { metricsPath } = options;


### PR DESCRIPTION
By adding `app.disable('x-powered-by');` we remove the header from the middleware and then its the job of the main application to either show or hide the header