### PR TITLE
feat: allow metrics to be served under a custom app

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm i --save express-prometheus-middleware
 | Name | Description | Default |
 | :-: | :- | :- |
 | metricsPath | Url route that will expose the metrics for scraping. | `/metrics` |
+| metricsApp  | Express app that will expose metrics endpoint | `same app as the middleware` |
 | collectDefaultMetrics | Whether or not to collect `prom-client` default metrics. These metrics are usefull for collecting saturation metrics, for example. | `true` |
 | requestDurationBuckets | Buckets for the request duration metrics (in milliseconds) histogram | Uses `prom-client` utility: `Prometheus.exponentialBuckets(0.05, 1.75, 8)` |
 | authenticate | Optional authentication callback, the function should receive as argument, the `req` object and return truthy for sucessfull authentication, or falsy, otherwise. This option supports Promise results. | `null` |

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,12 @@ const {
   normalizePath,
 } = require('./normalizers');
 
+
+const app = express();
+
 const defaultOptions = {
   metricsPath: '/metrics',
+  metricsApp: app,
   authenticate: null,
   collectDefaultMetrics: true,
   // buckets for response time from 0.05s to 2.5s
@@ -22,11 +26,10 @@ const defaultOptions = {
 };
 
 module.exports = (userOptions = {}) => {
-  const app = express();
   app.disable('x-powered-by');
   const options = Object.assign({}, defaultOptions, userOptions);
 
-  const { metricsPath } = options;
+  const { metricsPath, metricsApp } = options;
   const requestDuration = requestDurationGenerator(options.requestDurationBuckets);
 
   /**
@@ -62,7 +65,7 @@ module.exports = (userOptions = {}) => {
   /**
    * Metrics route to be used by prometheus to scrape metrics
    */
-  app.get(metricsPath, async (req, res, next) => {
+  metricsApp.get(metricsPath, async (req, res, next) => {
     if (typeof options.authenticate === 'function') {
       let result = null;
       try {


### PR DESCRIPTION
create a property called `metricsApp`, so that the metrics endpoint
can be served under a different application.

the use case is to run in kubernetes, where metrics app can run
in a different port, that's only exposed within the cluster.