### PR TITLE
feat: add metrics for request length and response length

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm i --save express-prometheus-middleware
 | collectDefaultMetrics | Whether or not to collect `prom-client` default metrics. These metrics are usefull for collecting saturation metrics, for example. | `true` |
 | collectGCMetrics | Whether or not to collect garbage collection metrics via module `prometheus-gc-stats`. Dependency `prometheus-gc-stats` is marked as optional, hence if this option is set to `true` but npm/yarn could not install the dependency, no garbage collection metric will be collected. | `false` |
 | requestDurationBuckets | Buckets for the request duration metrics (in milliseconds) histogram | Uses `prom-client` utility: `Prometheus.exponentialBuckets(0.05, 1.75, 8)` |
+| requestLengthBuckets | Buckets for the request length metrics (in bytes) histogram | [512, 1024, 5120, 10240, 51200, 102400, 512000, 1048576, 5242880, 10485760] |
+| responseLengthBuckets | Buckets for the response length metrics (in bytes) histogram | [512, 1024, 5120, 10240, 51200, 102400, 512000, 1048576, 5242880, 10485760] |
 | extraMasks | Optional, list of regexes to be used as argument to [url-value-parser](https://www.npmjs.com/package/url-value-parser), this will cause extra route params,  to be replaced with a `#val` placeholder.  | no extra masks: `[]` |
 | authenticate | Optional authentication callback, the function should receive as argument, the `req` object and return truthy for sucessfull authentication, or falsy, otherwise. This option supports Promise results. | `null` |
 | prefix | Optional prefix for the metrics name | no prefix added |
@@ -46,6 +48,8 @@ app.use(promMid({
   metricsPath: '/metrics',
   collectDefaultMetrics: true,
   requestDurationBuckets: [0.1, 0.5, 1, 1.5],
+  requestLengthBuckets: [512, 1024, 5120, 10240, 51200, 102400],
+  responseLengthBuckets: [512, 1024, 5120, 10240, 51200, 102400],
   /**
    * Uncomenting the `authenticate` callback will make the `metricsPath` route
    * require authentication. This authentication callback can make a simple
@@ -119,6 +123,18 @@ sum(rate(http_requests_total{status="5XX", app="myapp"}[5m]))
 
 ```js
 histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{app="myapp"}[5m])) by (le))
+```
+
+#### 95% of request length
+
+```js
+histogram_quantile(0.95, sum(rate(http_request_length_bytes_bucket{app="myapp"}[5m])) by (le))
+```
+
+#### 95% of response length
+
+```js
+histogram_quantile(0.95, sum(rate(http_response_length_bytes_bucket{app="myapp"}[5m])) by (le))
 ```
 
 #### Average response time in seconds

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ npm i --save express-prometheus-middleware
 | collectDefaultMetrics | Whether or not to collect `prom-client` default metrics. These metrics are usefull for collecting saturation metrics, for example. | `true` |
 | collectGCMetrics | Whether or not to collect garbage collection metrics via module `prometheus-gc-stats`. Dependency `prometheus-gc-stats` is marked as optional, hence if this option is set to `true` but npm/yarn could not install the dependency, no garbage collection metric will be collected. | `false` |
 | requestDurationBuckets | Buckets for the request duration metrics (in milliseconds) histogram | Uses `prom-client` utility: `Prometheus.exponentialBuckets(0.05, 1.75, 8)` |
-| requestLengthBuckets | Buckets for the request length metrics (in bytes) histogram | [512, 1024, 5120, 10240, 51200, 102400, 512000, 1048576, 5242880, 10485760] |
-| responseLengthBuckets | Buckets for the response length metrics (in bytes) histogram | [512, 1024, 5120, 10240, 51200, 102400, 512000, 1048576, 5242880, 10485760] |
+| requestLengthBuckets | Buckets for the request length metrics (in bytes) histogram | no buckets (The request length metrics are not collected): `[]` |
+| responseLengthBuckets | Buckets for the response length metrics (in bytes) histogram | no buckets (The response length metrics are not collected) `[]` |
 | extraMasks | Optional, list of regexes to be used as argument to [url-value-parser](https://www.npmjs.com/package/url-value-parser), this will cause extra route params,  to be replaced with a `#val` placeholder.  | no extra masks: `[]` |
 | authenticate | Optional authentication callback, the function should receive as argument, the `req` object and return truthy for sucessfull authentication, or falsy, otherwise. This option supports Promise results. | `null` |
 | prefix | Optional prefix for the metrics name | no prefix added |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm i --save express-prometheus-middleware
 | prefix | Optional prefix for the metrics name | no prefix added |
 | customLabels | Optional Array containing extra labels, used together with  `transformLabels` | no extra labels: `[]` |
 | transformLabels | Optional `function(labels, req, res)` adds to the labels object dynamic values for each label in `customLabels` | `null` |
+| normalizeStatus | Optional parameter to disable normalization of the status code. Example of normalized and non-normalized status code respectively: 4xx and 422.| true
 ### Example
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -23,20 +23,8 @@ const defaultOptions = {
   // buckets for response time from 0.05s to 2.5s
   // these are arbitrary values since i dont know any better ¯\_(ツ)_/¯
   requestDurationBuckets: Prometheus.exponentialBuckets(0.05, 1.75, 8),
-  requestLengthBuckets: [
-    512, 1024, // Less than 1KiB
-    5120, 10240, // Between 1KiB to 10KiB
-    51200, 102400, // Between 10KiB to 100KiB
-    512000, 1048576, // Between 100KiB to 1MiB
-    5242880, 10485760, // Between 1MiB to 10MiB
-  ],
-  responseLengthBuckets: [
-    512, 1024, // Less than 1KiB
-    5120, 10240, // Between 1KiB to 10KiB
-    51200, 102400, // Between 10KiB to 100KiB
-    512000, 1048576, // Between 100KiB to 1MiB
-    5242880, 10485760, // Between 1MiB to 10MiB
-  ],
+  requestLengthBuckets: [],
+  responseLengthBuckets: [],
   extraMasks: [],
   customLabels: [],
   transformLabels: null,
@@ -96,15 +84,19 @@ module.exports = (userOptions = {}) => {
       requestDuration.observe(labels, time / 1000);
 
       // observe request length
-      const reqLength = req.get('Content-Length');
-      if (reqLength) {
-        requestLength.observe(labels, Number(reqLength));
+      if (options.requestLengthBuckets.length) {
+        const reqLength = req.get('Content-Length');
+        if (reqLength) {
+          requestLength.observe(labels, Number(reqLength));
+        }
       }
 
       // observe response length
-      const resLength = res.get('Content-Length');
-      if (resLength) {
-        responseLength.observe(labels, Number(resLength));
+      if (options.responseLengthBuckets.length) {
+        const resLength = res.get('Content-Length');
+        if (resLength) {
+          responseLength.observe(labels, Number(resLength));
+        }
       }
     }
   });

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -26,7 +26,37 @@ function requestDurationGenerator(labelNames, buckets, prefix = '') {
   });
 }
 
+/**
+ * @param {!Array} buckets - array of numbers, representing the buckets for
+ * @param prefix - metrics name prefix
+ * request length
+ */
+function requestLengthGenerator(labelNames, buckets, prefix = '') {
+  return new Prometheus.Histogram({
+    name: `${prefix}http_request_length_bytes`,
+    help: 'Content-Length of HTTP request',
+    labelNames,
+    buckets,
+  });
+}
+
+/**
+ * @param {!Array} buckets - array of numbers, representing the buckets for
+ * @param prefix - metrics name prefix
+ * response length
+ */
+function responseLengthGenerator(labelNames, buckets, prefix = '') {
+  return new Prometheus.Histogram({
+    name: `${prefix}http_response_length_bytes`,
+    help: 'Content-Length of HTTP response',
+    labelNames,
+    buckets,
+  });
+}
+
 module.exports = {
   requestCountGenerator,
   requestDurationGenerator,
+  requestLengthGenerator,
+  responseLengthGenerator,
 };


### PR DESCRIPTION
Hi,
I would like to add the new metrics for Request length and Response length.

Motivation:
If an API handles a large JSON in request or response, the latency might get worse.
So I would like to monitor them.