### PR TITLE
feat(option):  resetOnScrape boolean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm i --save express-prometheus-middleware
 | customLabels | Optional Array containing extra labels, used together with  `transformLabels` | no extra labels: `[]` |
 | transformLabels | Optional `function(labels, req, res)` adds to the labels object dynamic values for each label in `customLabels` | `null` |
 | normalizeStatus | Optional parameter to disable normalization of the status code. Example of normalized and non-normalized status code respectively: 4xx and 422.| true
+| resetOnScrape | Optional parameter to reset the metrics in the default registry after every scrape| true
 ### Example
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const defaultOptions = {
   customLabels: [],
   transformLabels: null,
   normalizeStatus: true,
+  resetOnScrape: false,
 };
 
 module.exports = (userOptions = {}) => {
@@ -155,7 +156,11 @@ module.exports = (userOptions = {}) => {
     }
 
     res.set('Content-Type', Prometheus.register.contentType);
-    return res.end(await Prometheus.register.metrics());
+    const result = res.end(await Prometheus.register.metrics());
+    if (options.resetOnScrape) {
+      Prometheus.register.resetMetrics();
+    }
+    return result;
   });
 
   return app;


### PR DESCRIPTION
body:
if set to true resetOnScrape will call resetMetrics on the default metric registry. This has the advantage that it will stop memo
ry piling up in the metrics themselves. promethues scrape performance degrades if the metrics return a lot of data.

Prometheus keeps deta that it scrapes in a time series database, so we don't need it hanging about, unless you are using long liv
ed counters.

resetOnScrape defaults to false